### PR TITLE
remove extra phrase from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # shelby
 
-The [Shelby Cobra](https://en.wikipedia.org/wiki/AC_Cobra) is an iconic sportscar as well as a monitoring agent monitoring agent for your unix system, written in Rust. Sends json metrics suitable for ingestion by [numbat](https://github.com/numbat-metrics).
+The [Shelby Cobra](https://en.wikipedia.org/wiki/AC_Cobra) is an iconic sportscar as well as a monitoring agent for your unix system, written in Rust. Sends json metrics suitable for ingestion by [numbat](https://github.com/numbat-metrics).
 
 ## Build
 


### PR DESCRIPTION
I removed a seemingly unnecessary "monitoring agent" phrase from the first section of the README.
Fixes #2 